### PR TITLE
Fix async type

### DIFF
--- a/static/i18n/en_US.yaml
+++ b/static/i18n/en_US.yaml
@@ -25,7 +25,7 @@ goroutines:
   first: "Haskell has a lightweight thread feature similar to Go."
   inter: "starts a new lightweight thread"
   overviewPreAsync:
-    '<code>async :: IO a -> Async a</code> is not special syntax, but a function.
+    '<code>async :: IO a -> IO (Async a)</code> is not special syntax, but a function.
     The function <code>async</code> is provided by the '
   overviewPostAsync:
     ' package'

--- a/static/i18n/ja_JP.yaml
+++ b/static/i18n/ja_JP.yaml
@@ -24,7 +24,7 @@ goroutines:
   first: "Haskell は Go と同じく軽量スレッドの機能を持っています。"
   inter: "これは新しい軽量スレッドを作り、その中で次の処理を起動します。"
   overviewPreAsync:
-    '<code>async :: IO a -> Async a</code> は何か特殊な構文というわけではなく通常の関数です。
+    '<code>async :: IO a -> IO (Async a)</code> は何か特殊な構文というわけではなく通常の関数です。
     <code>async</code> 関数は '
   overviewPostAsync:
     ' パッケージで提供されています。'


### PR DESCRIPTION
The Goroutines page shows the type of `async` as `IO a -> Async a`, whereas it should be `IO a -> IO (Async a)` instead ([docs](https://www.stackage.org/haddock/lts-10.3/async-2.1.1.1/Control-Concurrent-Async.html#v:async)).